### PR TITLE
Create new notes in text area

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.classpath
 /.project
 /dependency-reduced-pom.xml
+.idea

--- a/src/main/java/org/lightless/heroscribe/gui/TextAreaModal.java
+++ b/src/main/java/org/lightless/heroscribe/gui/TextAreaModal.java
@@ -1,0 +1,84 @@
+/*
+  Copyright (C) 2002-2004 Flavio Chierichetti and Valerio Chierichetti
+
+  HeroScribe Enhanced (changes are prefixed with HSE in comments)
+  Copyright (C) 2011 Jason Allen
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 2 (not
+  later versions) as published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+package org.lightless.heroscribe.gui;
+
+import javax.swing.*;
+import javax.swing.event.AncestorEvent;
+import javax.swing.event.AncestorListener;
+import java.awt.*;
+import java.util.Optional;
+
+public class TextAreaModal {
+
+	private final String title;
+	private final String label;
+	private final int rows;
+	private final int columns;
+
+	public TextAreaModal(String title, String label) {
+		this(title, label, 10, 50);
+	}
+
+	public TextAreaModal(String title, String label, int rows, int columns) {
+		this.title = title;
+		this.label = label;
+		this.rows = rows;
+		this.columns = columns;
+	}
+
+	public Optional<String> showDialog() {
+		final JPanel panel = new JPanel();
+		final JTextArea textArea = new JTextArea(rows, columns);
+
+		textArea.addAncestorListener(new RequestFocusListener());
+
+		panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+		panel.add(new Label(label));
+		panel.add(textArea);
+
+		final int option = JOptionPane.showOptionDialog(null, panel, title, JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null,
+				null);
+		if (option == JOptionPane.YES_OPTION) {
+			return Optional.ofNullable(textArea.getText());
+		}
+
+		return Optional.empty();
+	}
+
+	private static class RequestFocusListener implements AncestorListener {
+
+		@Override
+		public void ancestorAdded(AncestorEvent event) {
+			SwingUtilities.invokeLater(event.getComponent()::requestFocusInWindow);
+		}
+
+		@Override
+		public void ancestorRemoved(AncestorEvent event) {
+			// noop
+		}
+
+		@Override
+		public void ancestorMoved(AncestorEvent event) {
+			// noop
+		}
+	}
+
+}

--- a/src/main/java/org/lightless/heroscribe/gui/ToolsPanel.java
+++ b/src/main/java/org/lightless/heroscribe/gui/ToolsPanel.java
@@ -1,19 +1,19 @@
 /*
   HeroScribe
   Copyright (C) 2002-2004 Flavio Chierichetti and Valerio Chierichetti
-  
+
   HeroScribe Enhanced (changes are prefixed with HSE in comments)
-  Copyright (C) 2011 Jason Allen 
-  
+  Copyright (C) 2011 Jason Allen
+
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2 (not
   later versions) as published by the Free Software Foundation.
- 
+
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
- 
+
   You should have received a copy of the GNU General Public License
   along with this program; if not, write to the Free Software
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -21,41 +21,14 @@
 
 package org.lightless.heroscribe.gui;
 
-import java.awt.BorderLayout;
-import java.awt.CardLayout;
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.GridLayout;
-import java.awt.Insets;
-import java.awt.TextArea;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
-import java.util.Iterator;
-
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.ButtonGroup;
-import javax.swing.DefaultListModel;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JSeparator;
-import javax.swing.JTextField;
-import javax.swing.JToggleButton;
-import javax.swing.SwingConstants;
-import javax.swing.border.EtchedBorder;
-
 import org.lightless.heroscribe.list.LObject;
 import org.lightless.heroscribe.quest.Quest;
+
+import javax.swing.*;
+import javax.swing.border.EtchedBorder;
+import java.awt.*;
+import java.awt.event.*;
+import java.util.Iterator;
 
 public class ToolsPanel extends JPanel implements ItemListener, KeyListener, ActionListener {
 
@@ -330,14 +303,12 @@ public class ToolsPanel extends JPanel implements ItemListener, KeyListener, Act
 
 		} else if (e.getSource() == newNote) {
 			// HSE - listener for new note click
-			String response = JOptionPane.showInputDialog(null, "Enter the QuestMaster Note:", "Enter Note", JOptionPane.QUESTION_MESSAGE);
-			if (response != null) {
-				if (!response.isEmpty()) {
-					noteData.addElement(response);
-					quest.addNote(response);
-					quest.setModified(true);
-				}
-			}
+			final TextAreaModal modal = new TextAreaModal("Enter Note", "Enter the QuestMaster Note:");
+			modal.showDialog().ifPresent(text -> {
+				noteData.addElement(text);
+				quest.addNote(text);
+				quest.setModified(true);
+			});
 		} else if (e.getSource() == delNote) {
 			// HSE - listener for del note click
 			if (note.getSelectedValue() != null) {


### PR DESCRIPTION
**What did you change?**
* New notes are added in a text area instead of an input box. This could help users that need to enter long quest notes.

```
+---------------------------------+
|X          Enter Note            |
+---------------------------------+
|Enter teh QuestMaster Note:      |
|  +---------------------------+  |
|  |                           |  |
|  |                           |  |
|  +---------------------------+  |
|                                 |
|             +--------+ +------+ |
|             | Cancel | |  OK  | |
|             +--------+ +------+ |
|                                 |
+---------------------------------+
```

I don't know if this goes in the lines of what you have planned for the project.
If needed, I could also create a PR for editing the notes too.

Thank your for sharing and maintaining the project!